### PR TITLE
The wrong version number in LS_VERSION variable.

### DIFF
--- a/5.4/Dockerfile
+++ b/5.4/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer "https://github.com/blacktop"
 
 RUN apk add --no-cache openjdk8-jre tini su-exec
 
-ENV LS_VERSION 5.3.0
+ENV LS_VERSION 5.4.0
 ENV LOGSTASH_URL "https://artifacts.elastic.co/downloads/logstash"
 ENV LOGSTASH_TARBALL "$LOGSTASH_URL/logstash-${LS_VERSION}.tar.gz"
 ENV LOGSTASH_TARBALL_ASC "$LOGSTASH_URL/logstash-${LS_VERSION}.tar.gz.asc"


### PR DESCRIPTION
Hi! I also have checked the image on your dockerhub repository. It's logstash version 5.3 not version 5.4.